### PR TITLE
Add missing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+Image
+armstub
+bcm*.dtb
+image.*
+*.img
+keys
+optee
+*.dts
+u-boot

--- a/dependencies-22.04.txt
+++ b/dependencies-22.04.txt
@@ -3,6 +3,7 @@ acpica-tools
 autoconf
 automake
 bc
+binutils-aarch64-linux-gnu
 bison
 build-essential
 ccache
@@ -15,6 +16,8 @@ expect
 fastboot
 flex
 ftp-upload
+gcc
+gcc-aarch64-linux-gnu
 gdisk
 git
 libattr1-dev


### PR DESCRIPTION
Some dependencies for cross compilation for U-Boot were missing. These have been added to the dependencies list. 

In addition, a .gitignore as this was needed.