### PR TITLE
Feature rsa3072 by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,11 @@ fit: boot-files gen-keys
 	rm -f image.fit
 	# Sign the u-boot FDT
 	./config-its-u-boot.sh
-	./optee/u-boot/tools/mkimage -f image.its -K bcm2837-rpi-3-b-plus-u-boot.dtb -k keys -r image.fit
+	./u-boot/tools/mkimage -f image.its -K bcm2837-rpi-3-b-plus-u-boot.dtb -k keys -r image.fit
 	rm -f image.fit image.its
 	# Sign the linux DTB
 	./config-its-linux.sh
-	./optee/u-boot/tools/mkimage -f image.its -K bcm2710-rpi-3-b-plus-linux.dtb -k keys -r image.fit
+	./u-boot/tools/mkimage -f image.its -K bcm2710-rpi-3-b-plus-linux.dtb -k keys -r image.fit
 
 # For use with CONFIG_OF_EMBED
 rebuild-uboot:
@@ -138,7 +138,7 @@ keys:
 	mkdir keys
 
 keys/dev.key:
-	openssl genrsa -out keys/dev.key 2048
+	openssl genrsa -out keys/dev.key 3072
 	
 keys/dev.crt:
 	openssl req -batch -new -x509 -key keys/dev.key -out keys/dev.crt

--- a/config-its-linux.sh
+++ b/config-its-linux.sh
@@ -16,18 +16,6 @@ echo '/dts-v1/;
 				algo = "sha256";
 			};
 		};
-		tee-1 {
-			description = "bootloader";
-			data = /incbin/("kernel8.img");
-			type = "standalone";
-			arch = "arm64";
-			compression = "none";
-			load =  <0x08400000>;
-			entry = <0x08400000>;
-			hash-1 {
-				algo = "sha256";
-			};
-		};
 		fdt-1 {
 			description = "device tree";
 			data = /incbin/("bcm2710-rpi-3-b-plus-linux.dtb");
@@ -46,12 +34,11 @@ echo '/dts-v1/;
 		config-1 {
 			description = "default configuration";
 			kernel = "kernel-1";
-			loadables = "tee-1";
 			fdt = "fdt-1";
 			signature-1 {
-				algo = "sha256,rsa2048";
+				algo = "sha256,rsa3072";
 				key-name-hint = "dev";
-				sign-images = "fdt", "kernel", "loadables";
+				sign-images = "fdt", "kernel";
 			};
 		};
 	};

--- a/config-its-u-boot.sh
+++ b/config-its-u-boot.sh
@@ -16,18 +16,6 @@ echo '/dts-v1/;
 				algo = "sha256";
 			};
 		};
-		tee-1 {
-			description = "bootloader";
-			data = /incbin/("kernel8.img");
-			type = "standalone";
-			arch = "arm64";
-			compression = "none";
-			load =  <0x08400000>;
-			entry = <0x08400000>;
-			hash-1 {
-				algo = "sha256";
-			};
-		};
 		fdt-1 {
 			description = "device tree";
 			data = /incbin/("bcm2837-rpi-3-b-plus-u-boot.dtb");
@@ -46,12 +34,11 @@ echo '/dts-v1/;
 		config-1 {
 			description = "default configuration";
 			kernel = "kernel-1";
-			loadables = "tee-1";
 			fdt = "fdt-1";
 			signature-1 {
-				algo = "sha256,rsa2048";
+				algo = "sha256,rsa3072";
 				key-name-hint = "dev";
-				sign-images = "fdt", "kernel", "loadables";
+				sign-images = "fdt", "kernel";
 			};
 		};
 	};


### PR DESCRIPTION
This ensures the use of rsa3072 as default, instead of rsa2048 (insecure by 2030 from NIST).

Additionally, tee-1 subnode from images node was removed (kernel8.img). This was redundant and served no purpose in our FIT file.